### PR TITLE
Added configuration instructions for handling High DPI displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ overlay.exe [wind speed](0-999) [white text](1|0) [carrier ID](0-99)
 - [carrier ID] is a number indicating the carrier ID, 74 for the Stennis by default. Example: `overlay.exe 51 1 33`.
 
 Note: You can only omit options at the end. You have to add all previous ones. For example `overlay.exe 1` to set just the text color to white will not work.
+
+## Scaling in High DPI Displays
+If using scaling in Windows 10 on HiDPI displays disable it for the executable:
+- Right-click 'overlay.exe' and go to 'Properties'
+- Select the 'Compatibility' tab
+- Click 'Change high DPI settings'
+- Check 'Override high DPI scaling behavior.' and select 'System' under Scaling performed by:


### PR DESCRIPTION
With scaling enabled on HighDPI displays the LSO camera rectangles are not aligned in the screen. Added instructions on how to deal with this scenario.